### PR TITLE
Changed _internalCache access level to protected

### DIFF
--- a/amazon/Bucket.php
+++ b/amazon/Bucket.php
@@ -85,7 +85,7 @@ class Bucket extends BucketSubDirTemplate
      * @var array internal cache data.
      * This field is for the internal usage only.
      */
-    private $_internalCache = [];
+    protected $_internalCache = [];
 
 
     /**


### PR DESCRIPTION
Changed amazon\Bucket::$_internalCache access level to protected as in parent class  BucketSubDirTemplate.
